### PR TITLE
fix server crash on passing a filter

### DIFF
--- a/routes/geojson.js
+++ b/routes/geojson.js
@@ -98,14 +98,20 @@ module.exports = function (fastify, opts, next) {
             if (err) {
               reply.send(err)
             } else {
-              if (!result.rows[0].geojson) {
-                reply.code(204)
+              if (result.rows.length < 1) {
+                reply.code(404).send({
+                  statusCode: 404,
+                  error: 'No records found',
+                  code: '404',
+                  message: 'No records found matching your query',
+                });
+              } else {
+                const json = {
+                  type: 'FeatureCollection',
+                  features: result.rows.map((el) => JSON.parse(el.geojson)),
+                };
+                reply.send(json);
               }
-              const json = {
-                type: 'FeatureCollection',
-                features: result.rows.map(el => JSON.parse(el.geojson))
-              }
-              reply.send(json)
             }
           }
         )


### PR DESCRIPTION
server crash on passing a filter value that doesn't exist on the data, so instead return a 404 error or probably just an empty array! whatever resolves that crashing.