### PR TITLE
Remove superfluous `npm install` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM node:16-alpine
 WORKDIR /usr/src/app
 COPY package*.json ./
-RUN npm install
 RUN npm ci --only=production
 COPY . .
 EXPOSE 3000


### PR DESCRIPTION
Hello! This is a tiny PR to improve the `Dockerfile`. It removes an unnecessary `npm install` (it's redundant with the `npm ci` that comes right after it). That was my mistake.