### PR TITLE
Update Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # adapted from https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
-FROM node:16-alpine
+FROM node:20-alpine
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm ci --only=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # adapted from https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
-FROM node:20-alpine
+FROM node:20-slim
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm ci --only=production


### PR DESCRIPTION
This was primarily to upgrade the Docker image from Node 16 => 20 (current LTS), however the Docker Desktop app also suggested using `slim` instead of `alpine`. According to this post from Snyk it's [more official/supported](https://snyk.io/blog/choosing-the-best-node-js-docker-image/).