### PR TITLE
Add SSL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,6 @@ If you see an error like
 no pg_hba.conf entry for host <host>, user <user>, database <database>, no encryption
 ```
 
-you made need to connect to your server over SSL. Obtain a CA certificate and set `SSL_ROOT_CERT_PATH=<path to the certificate>` in `.env`.
+you made need to connect to your server over SSL. Obtain a CA certificate and set `SSL_ROOT_CERT_PATH=<path to the certificate>` in `.env`. If you're still getting an error, check the end of your connection string for `?sslmode=require` and try removing it. You should still be able to connect over SSL.
 
 If you can't get a certificate or want to bypass the error, you can try setting `NODE_TLS_REJECT_UNAUTHORIZED=0`. Note that this is unsafe and is not recommended in production.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,6 @@ If you see an error like
 no pg_hba.conf entry for host <host>, user <user>, database <database>, no encryption
 ```
 
-you made need to connect to your server over SSL. Obtain a CA certificate and set `SSL_ROOT_CERT_PATH=<path to the certificate>` in `.env`. If you're still getting an error, check the end of your connection string for `?sslmode=require` and try removing it. You should still be able to connect over SSL.
+you may need to connect to your server over SSL. Obtain a CA certificate and set `SSL_ROOT_CERT_PATH=<path to the certificate>` in `.env`. If you're still getting an error, check the end of your connection string for `?sslmode=require` and try removing it. You should still be able to connect over SSL.
 
 If you can't get a certificate or want to bypass the error, you can try setting `NODE_TLS_REJECT_UNAUTHORIZED=0`. Note that this is unsafe and is not recommended in production.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ This is the complete complete list of environmental variables that can be set.
 | CACHE_EXPIRESIN | No | 3600 | [Max age in seconds](https://github.com/fastify/fastify-caching) |
 | CACHE_SERVERCACHE | No | undefined | Max age in seconds for [shared cache](https://github.com/fastify/fastify-caching) (i.e. CDN) |
 | RATE_MAX | No | undefined | Requests per minute [rate limiter](https://github.com/fastify/fastify-rate-limit) (limiter not used if RATE_LIMIT not set)  |
-| SSL_ROOT_CERT_PATH | No | undefined | Path to a CA certificate if using TLS/SSL |
+| SSL_ROOT_CERT | No | undefined | Contents of a CA certificate for connecting over SSL. Use this if you need to store the entire certificate in an environment variable, e.g. for Docker. |
+| SSL_ROOT_CERT_PATH | No | undefined | Path to a CA certificate file for connecting over SSL. Note that setting `SSL_ROOT_CERT` overrides this. |
 
 
 ### Step 3: fire it up!
@@ -162,5 +163,11 @@ no pg_hba.conf entry for host <host>, user <user>, database <database>, no encry
 ```
 
 you may need to connect to your server over SSL. Obtain a CA certificate and set `SSL_ROOT_CERT_PATH=<path to the certificate>` in `.env`. If you're still getting an error, check the end of your connection string for `?sslmode=require` and try removing it. You should still be able to connect over SSL.
+
+If you're running Dirt on Docker, it may be easier to pass the contents of the certificate with `SSL_ROOT_CERT`. Example:
+
+```bash
+docker run -dp 3000:3000 -e POSTGRES_CONNECTION=<connection string> -e SSL_ROOT_CERT=$(cat ca.crt) dirt
+```
 
 If you can't get a certificate or want to bypass the error, you can try setting `NODE_TLS_REJECT_UNAUTHORIZED=0`. Note that this is unsafe and is not recommended in production.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This is the complete complete list of environmental variables that can be set.
 | CACHE_EXPIRESIN | No | 3600 | [Max age in seconds](https://github.com/fastify/fastify-caching) |
 | CACHE_SERVERCACHE | No | undefined | Max age in seconds for [shared cache](https://github.com/fastify/fastify-caching) (i.e. CDN) |
 | RATE_MAX | No | undefined | Requests per minute [rate limiter](https://github.com/fastify/fastify-rate-limit) (limiter not used if RATE_LIMIT not set)  |
+| SSL_ROOT_CERT_PATH | No | undefined | Path to a CA certificate if using TLS/SSL |
 
 
 ### Step 3: fire it up!
@@ -151,3 +152,15 @@ map.on('load', function() {
 ### Changes require a Restart
 
 If you modify code or add a route, dirt will not see it until dirt is restarted.
+
+### TLS/SSL
+
+If you see an error like
+
+```
+no pg_hba.conf entry for host <host>, user <user>, database <database>, no encryption
+```
+
+you made need to connect to your server over SSL. Obtain a CA certificate and set `SSL_ROOT_CERT_PATH=<path to the certificate>` in `.env`.
+
+If you can't get a certificate or want to bypass the error, you can try setting `NODE_TLS_REJECT_UNAUTHORIZED=0`. Note that this is unsafe and is not recommended in production.

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const path = require('path')
 require("dotenv").config()
 
@@ -18,9 +19,14 @@ if (!("POSTGRES_CONNECTION" in process.env)) {
 }
 
 // POSTGRES CONNECTION
-fastify.register(require('@fastify/postgres'), {
-  connectionString: process.env.POSTGRES_CONNECTION
-})
+const postgresConfig = { connectionString: process.env.POSTGRES_CONNECTION }
+
+if (process.env.SSL_ROOT_CERT_PATH) {
+  const ca = fs.readFileSync(process.env.SSL_ROOT_CERT_PATH).toString()
+  postgresConfig.ssl = { ca }
+}
+
+fastify.register(require('@fastify/postgres'), postgresConfig)
 
 // COMPRESSION
 // add x-protobuf

--- a/index.js
+++ b/index.js
@@ -21,9 +21,14 @@ if (!("POSTGRES_CONNECTION" in process.env)) {
 // POSTGRES CONNECTION
 const postgresConfig = { connectionString: process.env.POSTGRES_CONNECTION }
 
-if (process.env.SSL_ROOT_CERT_PATH) {
-  const ca = fs.readFileSync(process.env.SSL_ROOT_CERT_PATH).toString()
-  postgresConfig.ssl = { ca }
+if (process.env.SSL_ROOT_CERT) {
+  postgresConfig.ssl = {
+    ca: process.env.SSL_ROOT_CERT
+  }
+} else if (process.env.SSL_ROOT_CERT_PATH) {
+  postgresConfig.ssl = {
+    ca: fs.readFileSync(process.env.SSL_ROOT_CERT_PATH).toString()
+  }
 }
 
 fastify.register(require('@fastify/postgres'), postgresConfig)


### PR DESCRIPTION
I was trying to run Dirt against a managed/cloud Postgres server and got an error about SSL, so I added some optional config for using an SSL cert for servers that require it. I updated the README to describe the setting.